### PR TITLE
Fix MSBuild error: path format not supported

### DIFF
--- a/.github/workflows/official-build.yaml
+++ b/.github/workflows/official-build.yaml
@@ -31,6 +31,10 @@ jobs:
       run: dotnet test --verbosity normal
       working-directory: src/ReferenceCop.Roslyn.Tests
 
+    - name: Run Tests in ReferenceCop.MSBuild.Tests
+      run: dotnet test --verbosity normal
+      working-directory: src/ReferenceCop.MSBuild.Tests
+
     - name: Set NuGet Package Version Environment Variable from tag (only for tagged builds)
       if: ${{ github.ref_type == 'tag' }}
       env:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -30,3 +30,7 @@ jobs:
     - name: Run Tests in ReferenceCop.Roslyn.Tests
       run: dotnet test --verbosity normal
       working-directory: src/ReferenceCop.Roslyn.Tests
+
+    - name: Run Tests in ReferenceCop.MSBuild.Tests
+      run: dotnet test --verbosity normal
+      working-directory: src/ReferenceCop.MSBuild.Tests

--- a/README.md
+++ b/README.md
@@ -20,24 +20,28 @@ In case you are using [Central Package Management](https://learn.microsoft.com/e
 </ItemGroup>
 ```
 
-2. Add a `ReferenceCop.config` file to your project and define the repository root for ReferenceCop to use:
+2. Add a `ReferenceCop.config` file to your project and define the repository root for ReferenceCop to use. Please make sure
+the add the respective `ReferenceCopConfig` Label node:
 
 ```
 <ItemGroup>
-    <AdditionalFiles Include="./ReferenceCop.config" />
+    <AdditionalFiles Include="./ReferenceCop.config">
+        <Label>ReferenceCopConfig</Label>
+    </AdditionalFiles>
 </ItemGroup>
+```
 
+3. Define the `ReferenceCopRepositoryRoot` property. This is used to define the root of the repository where the project is located. 
+This is used to resolve the paths of the project references. The recommended value for `ReferenceCopRepositoryRoot` is `$(MSBuildStartupDirectory)` 
+as this will typically be the root of the solution where the project is located. If this does not work for your project, you can set the value to a different path.
+
+```
 <PropertyGroup>
     <ReferenceCopRepositoryRoot>$(MSBuildStartupDirectory)</ReferenceCopRepositoryRoot>
 </PropertyGroup>
-
 ```
 
-The `ReferenceCopRepositoryRoot` property is used to define the root of the repository where the project is located. This is used to resolve the paths of the project references.
-The recommended value for `ReferenceCopRepositoryRoot` is `$(MSBuildStartupDirectory)` as this will typically be the root of the solution where the project is located.
-If this does not work for your project, you can set the value to a different path.
-
-3. Build the project. You will see a set of warnings or errors based on the violations that were detected. Here are the diagnostic descriptors returned:
+4. Build the project. You will see a set of warnings or errors based on the violations that were detected. Here are the diagnostic descriptors returned:
 
 ## Configuration
 

--- a/src/ReferenceCop.MSBuild.Tests/Parsers/ConfigFilePathsParserTests.cs
+++ b/src/ReferenceCop.MSBuild.Tests/Parsers/ConfigFilePathsParserTests.cs
@@ -1,0 +1,106 @@
+﻿namespace ReferenceCop.MSBuild.Tests
+{
+    using System;
+    using FluentAssertions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ConfigFilePathsParserTests
+    {
+        private const string ValidPath = "C:\\config\\file1.config";
+        private const string AnotherValidPath = "C:\\config\\file2.config";
+        private const string EmptyPath = "   ";
+        private const string NullPath = null;
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsIsNull_ThrowsArgumentException()
+        {
+            // Arrange.
+            string configFilePaths = NullPath;
+
+            // Act.
+            Action act = () => ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsIsEmpty_ThrowsArgumentException()
+        {
+            // Arrange.
+            string configFilePaths = string.Empty;
+
+            // Act.
+            Action act = () => ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsContainsOnlyEmptyEntries_ThrowsInvalidOperationException()
+        {
+            // Arrange.
+            string configFilePaths = $"{EmptyPath};{EmptyPath}";
+
+            // Act.
+            Action act = () => ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsContainsMultipleValidPaths_ThrowsInvalidOperationException()
+        {
+            // Arrange.
+            string configFilePaths = $"{ValidPath};{AnotherValidPath}";
+
+            // Act.
+            Action act = () => ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsContainsSingleValidPath_ReturnsValidPath()
+        {
+            // Arrange.
+            string configFilePaths = ValidPath;
+
+            // Act.
+            string result = ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            result.Should().Be(ValidPath);
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsContainsValidPathWithWhitespace_ReturnsTrimmedValidPath()
+        {
+            // Arrange.
+            string configFilePaths = $"  {ValidPath}  ";
+
+            // Act.
+            string result = ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            result.Should().Be(ValidPath);
+        }
+
+        [TestMethod]
+        public void Parse_WhenConfigFilePathsContainsValidAndEmptyPaths_ReturnsValidPath()
+        {
+            // Arrange.
+            string configFilePaths = $"{EmptyPath};{ValidPath};{EmptyPath}";
+
+            // Act.
+            string result = ConfigFilePathsParser.Parse(configFilePaths);
+
+            // Assert.
+            result.Should().Be(ValidPath);
+        }
+    }
+}

--- a/src/ReferenceCop.MSBuild.Tests/ReferenceCop.MSBuild.Tests.csproj
+++ b/src/ReferenceCop.MSBuild.Tests/ReferenceCop.MSBuild.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReferenceCop.MSBuild\ReferenceCop.MSBuild.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReferenceCop.MSBuild/Parsers/ConfigFilePathsParser.cs
+++ b/src/ReferenceCop.MSBuild/Parsers/ConfigFilePathsParser.cs
@@ -1,0 +1,46 @@
+﻿namespace ReferenceCop.MSBuild
+{
+    using System;
+    using System.Linq;
+
+    internal class ConfigFilePathsParser
+    {
+        internal static readonly char[] Separator = new[] { ';' };
+
+        /// <summary>
+        /// Parses a semi-colon separated string of config file paths and returns a single valid path.
+        /// </summary>
+        /// <param name="configFilePaths">A semi-colon separated string of config file paths.</param>
+        /// <returns>A single valid config file path.</returns>
+        /// <exception cref="ArgumentException">Thrown when no file paths are provided.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when no valid paths are found or more than one path is provided.</exception>
+        /// <remarks>
+        /// This method is necessary because the AdditionalFiles property from MSBuild provides a string with multiple values separated by semi-colons.
+        /// It ensures that only one valid config file path is returned, as the application does not support multiple config file paths.
+        /// </remarks>
+        public static string Parse(string configFilePaths)
+        {
+            if (string.IsNullOrEmpty(configFilePaths))
+            {
+                throw new ArgumentException("No file paths were provided.", nameof(configFilePaths));
+            }
+
+            var paths = configFilePaths.Split(Separator, StringSplitOptions.RemoveEmptyEntries)
+                                      .Select(path => path.Trim())
+                                      .Where(path => !string.IsNullOrWhiteSpace(path))
+                                      .ToList();
+
+            if (paths.Count == 0)
+            {
+                throw new InvalidOperationException("No valid config file paths were found.");
+            }
+
+            if (paths.Count > 1)
+            {
+                throw new InvalidOperationException("More than one config file path is not supported.");
+            }
+
+            return paths.Single();
+        }
+    }
+}

--- a/src/ReferenceCop.MSBuild/ReferenceCop.MSBuild.csproj
+++ b/src/ReferenceCop.MSBuild/ReferenceCop.MSBuild.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" >
+    <PackageReference Include="Microsoft.CodeAnalysis">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ReferenceCop\ReferenceCop.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReferenceCop.MSBuild.Tests" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/ReferenceCop.MSBuild/ReferenceCop.targets
+++ b/src/ReferenceCop.MSBuild/ReferenceCop.targets
@@ -4,12 +4,13 @@
   <Target Name="RunReferenceCop" BeforeTargets="Build">
     <ItemGroup>
       <ProjectFile Include="$(MSBuildProjectFullPath)" />
+      <FilteredAdditionalFiles Include="@(AdditionalFiles)" Condition="'%(AdditionalFiles.Label)' == 'ReferenceCopConfig'" />
     </ItemGroup>
 
     <!-- Check if AdditionalFiles property is defined -->
     <!-- Throw an error if AdditionalFiles property is not defined -->
-    <Error Condition="!Exists('@(AdditionalFiles)')" Code="RC0000" Text="ReferenceCop configuration file was not found or defined in the AdditionalFiles property." />
+    <Error Condition="!Exists('@(FilteredAdditionalFiles)')" Code="RC0000" Text="ReferenceCop configuration file was not found or defined in the AdditionalFiles property." />
 
-    <ReferenceCopTask ProjectFile="@(ProjectFile)" ConfigFilePath="@(AdditionalFiles)" LaunchDebugger="$(LaunchDebugger)" />
+    <ReferenceCopTask ProjectFile="@(ProjectFile)" ConfigFilePaths="@(FilteredAdditionalFiles)" LaunchDebugger="$(LaunchDebugger)" />
   </Target>
 </Project>

--- a/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
+++ b/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
@@ -25,7 +25,7 @@
         public ITaskItem ProjectFile { get; set; }
 
         [Required]
-        public string ConfigFilePath { get; set; }
+        public string ConfigFilePaths { get; set; }
 
         public string LaunchDebugger { get; set; }
 
@@ -39,7 +39,8 @@
             bool success = true;
             try
             {
-                var configLoader = new XmlConfigurationLoader(ConfigFilePath);
+                var configFilePath = ConfigFilePathsParser.Parse(ConfigFilePaths);
+                var configLoader = new XmlConfigurationLoader(configFilePath);
                 var config = configLoader.Load();
 
                 var projectReferences = GetProjectReferencesFromCsproj();

--- a/src/ReferenceCop.sln
+++ b/src/ReferenceCop.sln
@@ -39,6 +39,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		..\.github\workflows\pr-build.yaml = ..\.github\workflows\pr-build.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceCop.MSBuild.Tests", "ReferenceCop.MSBuild.Tests\ReferenceCop.MSBuild.Tests.csproj", "{6A6D30A1-B0B9-409D-A5CF-BA414ACE0491}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{06921A6C-BA8A-43B3-9458-50470FB0EAAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06921A6C-BA8A-43B3-9458-50470FB0EAAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06921A6C-BA8A-43B3-9458-50470FB0EAAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A6D30A1-B0B9-409D-A5CF-BA414ACE0491}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A6D30A1-B0B9-409D-A5CF-BA414ACE0491}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A6D30A1-B0B9-409D-A5CF-BA414ACE0491}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A6D30A1-B0B9-409D-A5CF-BA414ACE0491}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Description
- **Ensure only one ReferenceCopConfig file is retrieved for MSBuild**
- **Update README**
- **Update workflows with new test project**

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
Via deploying package to local feed and verifying on a test project.

## Screenshots (if applicable)
N/A

## Additional context
N/A


