### PR TITLE
Fix PKGVERSION (Strip 'v' prefix from tag)

### DIFF
--- a/.github/workflows/official-build.yaml
+++ b/.github/workflows/official-build.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Set NuGet Package Version Environment Variable from tag (only for tagged builds)
       if: ${{ github.ref_type == 'tag' }}
-      run: echo "PKGVERSION=${{ github.ref_name }}" >> $env:GITHUB_ENV
+      run: echo "PKGVERSION=${{ github.ref_name#'v' }}" >> $env:GITHUB_ENV
 
     - name: Display NuGet Package Version Environment Variable (only for tagged builds)
       if: ${{ github.ref_type == 'tag' }}


### PR DESCRIPTION
## Description
-Fix PKGVERSION to use version from tag (strip 'v' prefix from tag)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
N/A

## Screenshots (if applicable)
N/A

## Additional context
N/A
