### PR TITLE
Enable SourceLink and Deterministic builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,4 +2,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+
+  <!-- Source Link Settings Section - Ref: https://github.com/dotnet/sourcelink/blob/main/README.md -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,4 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
+
+  <!-- Deterministic Builds Settings Section - Ref: https://github.com/clairernovotny/DeterministicBuilds -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />


### PR DESCRIPTION
## Description
Enable SourceLink and Deterministic builds for easier package debugging and package verification purposes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [X] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
N/A

## Screenshots (if applicable)
N/A

## Additional context
N/A
