### PR TITLE
Fix XSD ReferenceCopConfig schema

### DIFF
--- a/ReferenceCopConfig.xsd
+++ b/ReferenceCopConfig.xsd
@@ -5,40 +5,40 @@
       <xs:sequence>
         <xs:element name="Rules">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element name="AssemblyName" maxOccurs="unbounded">
+            <xs:choice maxOccurs="unbounded">
+              <xs:element name="AssemblyName">
                 <xs:complexType>
-                  <xs:sequence>
+                  <xs:all>
                     <xs:element name="Name" type="xs:string" />
                     <xs:element name="Description" type="xs:string" />
                     <xs:element name="Severity" type="xs:string" />
                     <xs:element name="Pattern" type="xs:string" />
-                  </xs:sequence>
+                  </xs:all>
                 </xs:complexType>
               </xs:element>
-              <xs:element name="ProjectTag" maxOccurs="unbounded">
+              <xs:element name="ProjectTag">
                 <xs:complexType>
-                  <xs:sequence>
+                  <xs:all>
                     <xs:element name="Name" type="xs:string" />
                     <xs:element name="Description" type="xs:string" />
                     <xs:element name="Severity" type="xs:string" />
                     <xs:element name="FromProjectTag" type="xs:string" />
                     <xs:element name="ToProjectTag" type="xs:string" />
-                  </xs:sequence>
+                  </xs:all>
                 </xs:complexType>
               </xs:element>
-              <xs:element name="ProjectPath" maxOccurs="unbounded">
+              <xs:element name="ProjectPath">
                 <xs:complexType>
-                  <xs:sequence>
+                  <xs:all>
                     <xs:element name="Name" type="xs:string" />
                     <xs:element name="Description" type="xs:string" />
                     <xs:element name="Severity" type="xs:string" />
                     <xs:element name="FromPath" type="xs:string" />
                     <xs:element name="ToPath" type="xs:string" />
-                  </xs:sequence>
+                  </xs:all>
                 </xs:complexType>
               </xs:element>
-            </xs:sequence>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
       </xs:sequence>

--- a/src/ReferenceCop.sln
+++ b/src/ReferenceCop.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 		..\global.json = ..\global.json
 		..\README.md = ..\README.md
+		..\ReferenceCopConfig.xsd = ..\ReferenceCopConfig.xsd
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferenceCop.Roslyn", "ReferenceCop.Roslyn\ReferenceCop.Roslyn.csproj", "{1DB93B03-1F4A-457F-92DC-03B535849112}"


### PR DESCRIPTION
## Description
Fix XSD ReferenceCopConfig schema to ensure that:

- Order of rule node types is irrelevant
- A missing rule node type is allowed
- More than one node of a type is allowed

This is achieved by making Rules a collection of "choice" rather than a "sequence", and for each rule node type to contain an "all" element collection.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
N?A

## Screenshots (if applicable)
N/A

## Additional context
N/A