### PR TITLE
Move PackageId from Package csproj to official build workflow

### DIFF
--- a/.github/workflows/official-build.yaml
+++ b/.github/workflows/official-build.yaml
@@ -46,6 +46,6 @@ jobs:
     - name: Publish NuGet Package (only for tagged builds)
       if: ${{ github.ref_type == 'tag' }}
       run: |
-        dotnet pack --configuration Release --no-build --output nupkgs /p:PackageVersion=$env:PKGVERSION
+        dotnet pack --configuration Release --no-build --output nupkgs /p:PackageVersion=$env:PKGVERSION /p:PackageId=ReferenceCop
         dotnet nuget push **/nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       working-directory: src/ReferenceCop.Package

--- a/src/ReferenceCop.Package/ReferenceCop.Package.csproj
+++ b/src/ReferenceCop.Package/ReferenceCop.Package.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>ReferenceCop</PackageId>
+    <!-- PackageId is set during the publishing step in the CI workflow (official-build.yaml) -->
+    <!-- This is to avoid the circular dependency between the dogfood package and the package project -->
     <Authors>Marco Fogliatto</Authors>
     <PackageLicenseUrl>https://github.com/mfogliatto/ReferenceCop/blob/main/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/mfogliatto/ReferenceCop</RepositoryUrl>


### PR DESCRIPTION
## Description
Move PackageId from Package csproj to official build workflow. This is to avoid the circular dependency between the dogfood package and the package project.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [X] Enhancement (repo)
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
Via CI workflow step.

## Screenshots (if applicable)
N/A

## Additional context
The ReferenceCop package for dogfooding will be integrated in a follow-up PR.
