### PR TITLE
Fix MSBuild task output when no errors are logged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ L10N.Integrations/phantom*
 
 # CAKE
 tools/
+
+# VS Code settings
+.vscode/mcp.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,13 +13,30 @@
                 "/property:GenerateFullPaths=true",
                 // Do not generate summary otherwise it leads to duplicate errors in Problems panel
                 "/consoleloggerparameters:NoSummary",
-                "${workspaceFolder}/src"
+                "${fileDirname}"
             ],
             "group": "build",
             "presentation": {
                 "reveal": "silent"
             },
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "pack",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "pack",
+                "${fileDirname}",
+                "--configuration",
+                "Debug",
+                "/property:GenerateFullPaths=true"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": []
         }
     ]
 }

--- a/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
+++ b/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
@@ -44,11 +44,13 @@
                 var config = configLoader.Load();
 
                 var projectReferences = GetProjectReferencesFromCsproj();
-
                 this.tagViolationDetector = new ProjectTagViolationDetector(config, ProjectFile.ItemSpec, new ProjectTagProvider());
                 foreach (var violation in this.tagViolationDetector.GetViolationsFrom(projectReferences))
                 {
-                    success = false;
+                    if (violation.Rule.Severity == ReferenceCopConfig.Rule.ViolationSeverity.Error)
+                    {
+                        success = false;
+                    }
                     BuildEngine.LogViolation(violation, ProjectFile.ItemSpec);
                 }
 
@@ -56,7 +58,10 @@
                 this.pathViolationDetector = new ProjectPathViolationDetector(config, ProjectFile.ItemSpec, new ProjectPathProvider(repositoryRoot));
                 foreach (var violation in this.pathViolationDetector.GetViolationsFrom(projectReferences))
                 {
-                    success = false;
+                    if (violation.Rule.Severity == ReferenceCopConfig.Rule.ViolationSeverity.Error)
+                    {
+                        success = false;
+                    }
                     BuildEngine.LogViolation(violation, ProjectFile.ItemSpec);
                 }
             }


### PR DESCRIPTION
## Description
Fix build success status when only warnings are present.

This commit modifies the ReferenceCopTask class to only set the build success flag to false when violations with Error severity are detected. Previously, any violation (including warnings) would mark the build as failed, so if no errors were logged in such case, an MSB4181 general error would be returned instead. 

Now, the task will return success=true when only warnings are present, allowing builds to continue while still logging the warning messages.

The changes specifically affect how violations from both ProjectTagViolationDetector and ProjectPathViolationDetector are handled, adding severity checks before setting the success flag to false.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
By publising ReferenceCop to a local feed and running it agains a test project.

## Screenshots (if applicable)
Before the fix:
![image](https://github.com/user-attachments/assets/3e7912eb-649e-4e47-acd5-a50f1885854d)

After the fix:
![image](https://github.com/user-attachments/assets/9eac523a-6e2c-4e2a-a0bc-9345abc86b4e)

## Additional context
https://learn.microsoft.com/en-us/visualstudio/msbuild/errors/msb4181?view=vs-2022
