### PR TITLE
Refactor ReferenceCopTask with dependency injection and add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ tools/
 
 # VS Code settings
 .vscode/mcp.json
+
+# LLM Instruction files.
+claude.md

--- a/src/ReferenceCop.MSBuild.Tests/Providers/MSBuildProjectMetadataProviderTests.cs
+++ b/src/ReferenceCop.MSBuild.Tests/Providers/MSBuildProjectMetadataProviderTests.cs
@@ -1,0 +1,121 @@
+namespace ReferenceCop.MSBuild.Tests
+{
+    using System.IO;
+    using FluentAssertions;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class MSBuildProjectMetadataProviderTests
+    {
+        private const string TestPropertyName = "TestProperty";
+        private const string TestPropertyValue = "TestValue";
+        private const string TestReference = "TestReference.csproj";
+        
+        private MSBuildProjectMetadataProvider provider;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange the provider for each test
+            this.provider = new MSBuildProjectMetadataProvider();
+            
+            // Clean up any projects that might have been loaded in previous tests
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+        }
+        
+        [TestMethod]
+        public void GetProjectReferences_WhenProjectHasOneReference_ReturnsSingleReference()
+        {
+            // Arrange.
+            string tempProjectPath = CreateTempProjectFileWithReferences();
+            
+            try
+            {
+                // Act.
+                var references = this.provider.GetProjectReferences(tempProjectPath);
+                
+                // Assert.
+                references.Should().NotBeNull().And.ContainSingle(r => r == TestReference);
+            }
+            finally
+            {
+                // Cleanup
+                File.Delete(tempProjectPath);
+            }
+        }
+        
+        [TestMethod]
+        public void GetPropertyValue_WhenPropertyExists_ReturnsPropertyValue()
+        {
+            // Arrange.
+            string tempProjectPath = CreateTempProjectFileWithProperty();
+            
+            try
+            {
+                // Act.
+                string value = this.provider.GetPropertyValue(tempProjectPath, TestPropertyName);
+                
+                // Assert.
+                value.Should().Be(TestPropertyValue);
+            }
+            finally
+            {
+                // Cleanup
+                File.Delete(tempProjectPath);
+            }
+        }
+        
+        [TestMethod]
+        public void GetPropertyValue_WhenPropertyDoesNotExist_ReturnsEmptyString()
+        {
+            // Arrange.
+            string tempProjectPath = CreateTempProjectFileWithProperty();
+            const string nonExistentProperty = "NonExistentProperty";
+            
+            try
+            {
+                // Act.
+                string value = this.provider.GetPropertyValue(tempProjectPath, nonExistentProperty);
+                
+                // Assert.
+                value.Should().BeEmpty();
+            }
+            finally
+            {
+                // Cleanup
+                File.Delete(tempProjectPath);
+            }
+        }
+        
+        private string CreateTempProjectFileWithReferences()
+        {
+            string tempFile = Path.GetTempFileName() + ".csproj";
+            string projectContent = $@"
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include=""{TestReference}"" />
+  </ItemGroup>
+</Project>";
+            File.WriteAllText(tempFile, projectContent);
+            return tempFile;
+        }
+        
+        private string CreateTempProjectFileWithProperty()
+        {
+            string tempFile = Path.GetTempFileName() + ".csproj";
+            string projectContent = $@"
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <{TestPropertyName}>{TestPropertyValue}</{TestPropertyName}>
+  </PropertyGroup>
+</Project>";
+            File.WriteAllText(tempFile, projectContent);
+            return tempFile;
+        }
+    }
+}

--- a/src/ReferenceCop.MSBuild.Tests/ReferenceCop.MSBuild.Tests.csproj
+++ b/src/ReferenceCop.MSBuild.Tests/ReferenceCop.MSBuild.Tests.csproj
@@ -12,9 +12,10 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
-    <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="NSubstitute" />
   </ItemGroup>
 

--- a/src/ReferenceCop.MSBuild.Tests/ReferenceCopTaskTests.cs
+++ b/src/ReferenceCop.MSBuild.Tests/ReferenceCopTaskTests.cs
@@ -1,0 +1,155 @@
+namespace ReferenceCop.MSBuild.Tests
+{
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Microsoft.Build.Framework;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NSubstitute;
+    using ReferenceCop;
+
+    [TestClass]
+    public class ReferenceCopTaskTests
+    {
+        [TestMethod]
+        public void Execute_WhenViolationHasWarningSeverity_ReturnsTrue()
+        {
+            // Arrange.
+            var fakeBuildEngine = Substitute.For<IBuildEngine>();
+            var tagViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var pathViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var fakeProjectReferencesProvider = Substitute.For<IProjectMetadataProvider>();
+            var fakeConfigLoader = Substitute.For<IConfigurationLoader>();
+            var taskItem = Substitute.For<ITaskItem>();
+            taskItem.ItemSpec.Returns("TestProject.csproj");
+
+            var rule = new ReferenceCopConfig.AssemblyName { Severity = ReferenceCopConfig.Rule.ViolationSeverity.Warning };
+            var warningViolation = new Violation(rule, "TestReference");
+
+            // Setup the fake IProjectMetadataProvider
+            fakeProjectReferencesProvider.GetProjectReferences(Arg.Any<string>())
+                .Returns(new List<string> { "ReferenceProject.csproj" });
+            fakeProjectReferencesProvider.GetPropertyValue(Arg.Any<string>(), Arg.Any<string>())
+                .Returns("C:\\path\\to\\repo");
+
+            tagViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation> { warningViolation });
+            pathViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation>());
+
+            fakeConfigLoader.Load().Returns(new ReferenceCopConfig());
+
+            var task = new ReferenceCopTask(fakeProjectReferencesProvider, fakeConfigLoader, tagViolationDetector, pathViolationDetector)
+            {
+                BuildEngine = fakeBuildEngine,
+                ProjectFile = taskItem,
+                ConfigFilePaths = "C:\\path\\to\\config.xml",
+            };
+
+            // Act.
+            bool result = task.Execute();
+
+            // Assert.
+            result.Should().BeTrue();
+
+            // Verify that LogViolation was called with the warning violation
+            fakeBuildEngine.Received().LogWarningEvent(Arg.Any<BuildWarningEventArgs>());
+            fakeBuildEngine.DidNotReceive().LogErrorEvent(Arg.Any<BuildErrorEventArgs>());
+        }
+
+        [TestMethod]
+        public void Execute_WhenViolationHasErrorSeverity_ReturnsFalse()
+        {
+            // Arrange.
+            var fakeBuildEngine = Substitute.For<IBuildEngine>();
+            var taskItem = Substitute.For<ITaskItem>();
+            taskItem.ItemSpec.Returns("TestProject.csproj");
+
+            var tagViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var pathViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var fakeProjectReferencesProvider = Substitute.For<IProjectMetadataProvider>();
+            var fakeConfigLoader = Substitute.For<IConfigurationLoader>();
+
+            // Setup the fake IProjectReferencesProvider
+            fakeProjectReferencesProvider.GetProjectReferences(Arg.Any<string>())
+                .Returns(new List<string> { "ReferenceProject.csproj" });
+            fakeProjectReferencesProvider.GetPropertyValue(Arg.Any<string>(), Arg.Any<string>())
+                .Returns("C:\\path\\to\\repo");
+
+            var rule = new ReferenceCopConfig.AssemblyName { Severity = ReferenceCopConfig.Rule.ViolationSeverity.Error };
+            var errorViolation = new Violation(rule, "TestReference");
+
+            tagViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation> { errorViolation });
+            pathViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation>());
+
+            fakeConfigLoader.Load().Returns(new ReferenceCopConfig());
+
+            var task = new ReferenceCopTask(fakeProjectReferencesProvider, fakeConfigLoader, tagViolationDetector, pathViolationDetector)
+            {
+                BuildEngine = fakeBuildEngine,
+                ProjectFile = taskItem,
+                ConfigFilePaths = "C:\\path\\to\\config.xml",
+            };
+
+            // Act
+            bool result = task.Execute();
+
+            // Assert
+            result.Should().BeFalse();
+
+            // Verify that LogViolation was called with the error violation
+            fakeBuildEngine.Received().LogErrorEvent(Arg.Any<BuildErrorEventArgs>());
+            fakeBuildEngine.DidNotReceive().LogWarningEvent(Arg.Any<BuildWarningEventArgs>());
+        }
+
+        [TestMethod]
+        public void Execute_WhenHasBothErrorAndWarningSeverities_ReturnsFalse()
+        {
+            // Arrange
+            var fakeBuildEngine = Substitute.For<IBuildEngine>();
+            var taskItem = Substitute.For<ITaskItem>();
+            taskItem.ItemSpec.Returns("TestProject.csproj");
+
+            var tagViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var pathViolationDetector = Substitute.For<IViolationDetector<string>>();
+            var fakeProjectReferencesProvider = Substitute.For<IProjectMetadataProvider>();
+            var fakeConfigLoader = Substitute.For<IConfigurationLoader>();
+
+            // Setup the fake IProjectReferencesProvider
+            fakeProjectReferencesProvider.GetProjectReferences(Arg.Any<string>())
+                .Returns(new List<string> { "ReferenceProject.csproj" });
+            fakeProjectReferencesProvider.GetPropertyValue(Arg.Any<string>(), Arg.Any<string>())
+                .Returns("C:\\path\\to\\repo");
+
+            var errorRule = new ReferenceCopConfig.AssemblyName { Severity = ReferenceCopConfig.Rule.ViolationSeverity.Error };
+            var warningRule = new ReferenceCopConfig.AssemblyName { Severity = ReferenceCopConfig.Rule.ViolationSeverity.Warning };
+            var errorViolation = new Violation(errorRule, "TestErrorReference");
+            var warningViolation = new Violation(warningRule, "TestWarningReference");
+
+            tagViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation> { errorViolation });
+            pathViolationDetector.GetViolationsFrom(Arg.Any<IEnumerable<string>>())
+                .Returns(new List<Violation> { warningViolation });
+
+            fakeConfigLoader.Load().Returns(new ReferenceCopConfig());
+
+            var task = new ReferenceCopTask(fakeProjectReferencesProvider, fakeConfigLoader, tagViolationDetector, pathViolationDetector)
+            {
+                BuildEngine = fakeBuildEngine,
+                ProjectFile = taskItem,
+                ConfigFilePaths = "C:\\path\\to\\config.xml",
+            };
+
+            // Act
+            bool result = task.Execute();
+
+            // Assert
+            result.Should().BeFalse();
+
+            // Verify that LogViolation was called with both violations
+            fakeBuildEngine.Received().LogErrorEvent(Arg.Any<BuildErrorEventArgs>());
+            fakeBuildEngine.Received().LogWarningEvent(Arg.Any<BuildWarningEventArgs>());
+        }
+    }
+}

--- a/src/ReferenceCop.MSBuild/Providers/IProjectMetadataProvider.cs
+++ b/src/ReferenceCop.MSBuild/Providers/IProjectMetadataProvider.cs
@@ -1,0 +1,25 @@
+namespace ReferenceCop.MSBuild
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides project metadata from csproj files.
+    /// </summary>
+    public interface IProjectMetadataProvider
+    {
+        /// <summary>
+        /// Gets the project references from a project file.
+        /// </summary>
+        /// <param name="projectFilePath">The path to the project file.</param>
+        /// <returns>The collection of project references.</returns>
+        IEnumerable<string> GetProjectReferences(string projectFilePath);
+
+        /// <summary>
+        /// Gets a resolved property value from a project file.
+        /// </summary>
+        /// <param name="projectFilePath">The path to the project file.</param>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The resolved property value.</returns>
+        string GetPropertyValue(string projectFilePath, string propertyName);
+    }
+}

--- a/src/ReferenceCop.MSBuild/Providers/MSBuildProjectMetadataProvider.cs
+++ b/src/ReferenceCop.MSBuild/Providers/MSBuildProjectMetadataProvider.cs
@@ -1,0 +1,46 @@
+namespace ReferenceCop.MSBuild
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Build.Evaluation;
+
+    /// <summary>
+    /// Provides project reference information using MSBuild project evaluation.
+    /// </summary>
+    public class MSBuildProjectMetadataProvider : IProjectMetadataProvider
+    {
+        private const string ProjectReferenceNode = "ProjectReference";
+
+        /// <summary>
+        /// Gets the project references from a project file.
+        /// </summary>
+        /// <param name="projectFilePath">The path to the project file.</param>
+        /// <returns>The collection of project references.</returns>
+        public IEnumerable<string> GetProjectReferences(string projectFilePath)
+        {
+            var projectCollection = new ProjectCollection();
+            var project = projectCollection.LoadProject(projectFilePath);
+
+            // Get all ProjectReference items. These are the direct project references.
+            var projectReferences = project.GetItems(ProjectReferenceNode);
+
+            // Extract the Include attribute, which contains the path to the referenced project.
+            return projectReferences.Select(pr => pr.EvaluatedInclude);
+        }
+
+        /// <summary>
+        /// Gets a resolved property value from a project file.
+        /// </summary>
+        /// <param name="projectFilePath">The path to the project file.</param>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The resolved property value.</returns>
+        public string GetPropertyValue(string projectFilePath, string propertyName)
+        {
+            var projectCollection = new ProjectCollection();
+            var project = projectCollection.LoadProject(projectFilePath);
+            project.ReevaluateIfNecessary();
+
+            return project.GetPropertyValue(propertyName);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR improves the architecture and testability of the MSBuild task by implementing a dependency injection pattern and adding comprehensive test coverage. The changes decouple the core ReferenceCopTask from MSBuild implementation details, enable easier mocking for tests, and verify the severity-based warning/error behavior.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change

## Related Issue
N/A

## How Has This Been Tested?
- Added unit tests for MSBuildProjectMetadataProvider that verify:
  - Project reference extraction from csproj files
  - Property value resolution
  - Handling of non-existent properties

- Added unit tests for ReferenceCopTask that verify:
  - Task returns true when only warnings are detected
  - Task returns false when errors are detected
  - Correct behavior with mixed error and warning violations
  - Proper logging through the build engine

## Screenshots (if applicable)
N/A

## Additional context
N/A
