### PR TITLE
fix: cache project tag lookups to avoid redundant XML parsing

### DIFF
--- a/src/ReferenceCop/Providers/ProjectTagProvider.cs
+++ b/src/ReferenceCop/Providers/ProjectTagProvider.cs
@@ -1,5 +1,6 @@
 namespace ReferenceCop
 {
+    using System.Collections.Concurrent;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
@@ -12,20 +13,25 @@ namespace ReferenceCop
         internal const string ProjectTagNode = "ProjectTag";
         internal const string UnknownProjectTag = "Unknown";
 
+        private readonly ConcurrentDictionary<string, string> _cache = new();
+
         public string GetProjectTag(string projectFilePath)
         {
-            if (!File.Exists(projectFilePath))
+            return _cache.GetOrAdd(projectFilePath, path =>
             {
-                return UnknownProjectTag;
-            }
+                if (!File.Exists(path))
+                {
+                    return UnknownProjectTag;
+                }
 
-            var projectFile = XDocument.Load(projectFilePath);
-            var projectTag = projectFile
-                .Descendants(PropertyGroupNode)
-                .Elements(ProjectTagNode)
-                .FirstOrDefault()?.Value;
+                var projectFile = XDocument.Load(path);
+                var projectTag = projectFile
+                    .Descendants(PropertyGroupNode)
+                    .Elements(ProjectTagNode)
+                    .FirstOrDefault()?.Value;
 
-            return projectTag ?? UnknownProjectTag;
+                return projectTag ?? UnknownProjectTag;
+            });
         }
     }
 }

--- a/src/ReferenceCop/Providers/ProjectTagProvider.cs
+++ b/src/ReferenceCop/Providers/ProjectTagProvider.cs
@@ -13,11 +13,11 @@ namespace ReferenceCop
         internal const string ProjectTagNode = "ProjectTag";
         internal const string UnknownProjectTag = "Unknown";
 
-        private readonly ConcurrentDictionary<string, string> _cache = new();
+        private readonly ConcurrentDictionary<string, string> cache = new ConcurrentDictionary<string, string>();
 
         public string GetProjectTag(string projectFilePath)
         {
-            return _cache.GetOrAdd(projectFilePath, path =>
+            return this.cache.GetOrAdd(projectFilePath, path =>
             {
                 if (!File.Exists(path))
                 {


### PR DESCRIPTION
## Summary

Caches the result of `ProjectTagProvider.GetProjectTag()` using a `ConcurrentDictionary`, so each project file is read and parsed at most once per analyzer lifetime instead of once per rule × reference combination.

## Changes

- Added `ConcurrentDictionary<string, string>` cache to `ProjectTagProvider`
- Replaced direct file I/O with `_cache.GetOrAdd()` call
- Added `System.Collections.Concurrent` using directive

## Testing

No dotnet SDK available in CI environment; change is minimal and mechanical. Existing tests should pass unchanged since behavior is identical (same inputs → same outputs, just cached).

Fixes mfogliatto/ReferenceCop#51