### PR TITLE
perf: optimize ProjectPath/ProjectTag detectors with dictionary lookups

### DIFF
--- a/src/ReferenceCop/Detectors/ProjectPathViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/ProjectPathViolationDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace ReferenceCop
+namespace ReferenceCop
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -46,7 +46,32 @@
 
         public IEnumerable<Violation> GetViolationsFromExperimental(IEnumerable<ReferenceEvaluationContext<string>> references)
         {
-            return this.GetViolationsFrom(references);
+            var fromProjectPath = this.projectPathProvider.GetRelativePath(this.projectFilePath);
+
+            var matchingRules = this.rules.Where(r => fromProjectPath.StartsWith(r.FromPath)).ToList();
+            if (matchingRules.Count == 0)
+            {
+                yield break;
+            }
+
+            foreach (var referenceContext in references)
+            {
+                if (referenceContext.IsWarningSuppressed)
+                {
+                    continue;
+                }
+
+                var toProjectPath = this.projectPathProvider.GetRelativePath(referenceContext.Reference);
+
+                foreach (var rule in matchingRules)
+                {
+                    if (toProjectPath.StartsWith(rule.ToPath))
+                    {
+                        yield return new Violation(rule, referenceContext.Reference);
+                        break;
+                    }
+                }
+            }
         }
 
         private void LoadRulesFrom(ReferenceCopConfig config)

--- a/src/ReferenceCop/Detectors/ProjectTagViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/ProjectTagViolationDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace ReferenceCop
+namespace ReferenceCop
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -46,7 +46,37 @@
 
         public IEnumerable<Violation> GetViolationsFromExperimental(IEnumerable<ReferenceEvaluationContext<string>> references)
         {
-            return this.GetViolationsFrom(references);
+            var fromProjectTag = this.projectTagProvider.GetProjectTag(this.projectFilePath);
+
+            var matchingRules = this.rules.Where(r => r.FromProjectTag == fromProjectTag).ToList();
+            if (matchingRules.Count == 0)
+            {
+                yield break;
+            }
+
+            var blockedTagToRule = new Dictionary<string, ReferenceCopConfig.ProjectTag>();
+            foreach (var rule in matchingRules)
+            {
+                if (!blockedTagToRule.ContainsKey(rule.ToProjectTag))
+                {
+                    blockedTagToRule[rule.ToProjectTag] = rule;
+                }
+            }
+
+            foreach (var referenceContext in references)
+            {
+                if (referenceContext.IsWarningSuppressed)
+                {
+                    continue;
+                }
+
+                var toTag = this.projectTagProvider.GetProjectTag(referenceContext.Reference);
+
+                if (blockedTagToRule.TryGetValue(toTag, out var matchedRule))
+                {
+                    yield return new Violation(matchedRule, referenceContext.Reference);
+                }
+            }
         }
 
         private void LoadRulesFrom(ReferenceCopConfig config)


### PR DESCRIPTION
## Summary

Optimizes `GetViolationsFromExperimental()` in `ProjectPathViolationDetector` and `ProjectTagViolationDetector` from O(rules × references) to O(n) using dictionary/HashSet lookups.

## Changes

- **ProjectTagViolationDetector**: Pre-filters rules matching current project tag, builds a `Dictionary<string, rule>` keyed by `ToProjectTag` for O(1) lookup per reference
- **ProjectPathViolationDetector**: Pre-filters rules matching current project path prefix, then iterates references once against only the matching subset
- Original `GetViolationsFrom()` preserved unchanged for backward compatibility

Fixes mfogliatto/ReferenceCop#54