### PR TITLE
perf: cache XmlSerializer as static field

### DIFF
--- a/src/ReferenceCop/Configuration/XmlConfigurationLoader.cs
+++ b/src/ReferenceCop/Configuration/XmlConfigurationLoader.cs
@@ -51,11 +51,11 @@
             }
         }
 
+        private static readonly XmlSerializer Serializer = new XmlSerializer(typeof(ReferenceCopConfig));
+
         private static ReferenceCopConfig ParseConfigFrom(Stream stream)
         {
-            var xmlSerializer = new XmlSerializer(typeof(ReferenceCopConfig));
-
-            return (ReferenceCopConfig)xmlSerializer.Deserialize(stream);
+            return (ReferenceCopConfig)Serializer.Deserialize(stream);
         }
     }
 }


### PR DESCRIPTION
## Summary

Caches the XmlSerializer instance as a static readonly field to avoid expensive runtime code generation on every config load.

## Changes

- Made XmlSerializer a static readonly field in XmlConfigurationLoader
- Removed per-call instantiation in ParseConfigFrom()

## Testing

- dotnet SDK not available in CI environment; change is minimal and safe

Fixes mfogliatto/ReferenceCop#50