### PR TITLE
fix: Introduce tracing capabilities for debugging rule triggers

### DIFF
--- a/ReferenceCopConfig.xsd
+++ b/ReferenceCopConfig.xsd
@@ -5,6 +5,7 @@
       <xs:sequence>
         <xs:element name="UseExperimentalDetectors" type="xs:boolean" minOccurs="0" />
         <xs:element name="EnableDebugMessages" type="xs:boolean" minOccurs="0" />
+        <xs:element name="EnableTracing" type="xs:boolean" minOccurs="0" />
         <xs:element name="Rules">
           <xs:complexType>
             <xs:choice maxOccurs="unbounded">

--- a/src/ReferenceCop.MSBuild/BuildEngineExtensions.cs
+++ b/src/ReferenceCop.MSBuild/BuildEngineExtensions.cs
@@ -27,6 +27,16 @@
             }
         }
 
+        public static void LogTraceMessage(this IBuildEngine self, string message)
+        {
+            var messageEvent = new BuildMessageEventArgs(
+                message: $"[TRACE]: {message}",
+                helpKeyword: default,
+                senderName: SenderName,
+                importance: MessageImportance.Normal);
+            self.LogMessageEvent(messageEvent);
+        }
+
         public static void LogDebugMessage(this IBuildEngine self, string message)
         {
             var warningEvent = new BuildWarningEventArgs(

--- a/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
+++ b/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
@@ -13,15 +13,16 @@
 
         private readonly IProjectMetadataProvider projectReferencesProvider;
         private readonly Func<string, IConfigurationLoader> configLoaderFactory;
-        private readonly Func<ReferenceCopConfig, string, IViolationDetector<string>> projectTagViolationDetectorFactory;
-        private readonly Func<ReferenceCopConfig, string, string, IViolationDetector<string>> projectPathViolationDetectorFactory;
+        private readonly Func<ReferenceCopConfig, string, ITraceWriter, IViolationDetector<string>> projectTagViolationDetectorFactory;
+        private readonly Func<ReferenceCopConfig, string, string, ITraceWriter, IViolationDetector<string>> projectPathViolationDetectorFactory;
+        private readonly Func<bool, ITraceWriter> traceWriterFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReferenceCopTask"/> class.
         /// The constructor for the ReferenceCopTask used by MSBuild.
         /// </summary>
         public ReferenceCopTask()
-            : this(new MSBuildProjectMetadataProvider(), null, null, null)
+            : this(new MSBuildProjectMetadataProvider(), null, null, null, null)
         {
         }
 
@@ -38,16 +39,40 @@
             IConfigurationLoader configLoader,
             IViolationDetector<string> tagViolationDetector,
             IViolationDetector<string> pathViolationDetector)
+            : this(projectReferencesProvider, configLoader, tagViolationDetector, pathViolationDetector, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceCopTask"/> class.
+        /// Full constructor supporting dependency injection of all components.
+        /// </summary>
+        public ReferenceCopTask(
+            IProjectMetadataProvider projectReferencesProvider,
+            IConfigurationLoader configLoader,
+            IViolationDetector<string> tagViolationDetector,
+            IViolationDetector<string> pathViolationDetector,
+            Func<bool, ITraceWriter> traceWriterFactory)
         {
             this.projectReferencesProvider = projectReferencesProvider;
 
             this.configLoaderFactory = (configFilePaths) => configLoader ?? new XmlConfigurationLoader(configFilePaths);
 
-            this.projectTagViolationDetectorFactory = (config, projectPath) =>
-                tagViolationDetector ?? new ProjectTagViolationDetector(config, projectPath, new ProjectTagProvider());
+            this.projectTagViolationDetectorFactory = (config, projectPath, tw) =>
+                tagViolationDetector ?? new ProjectTagViolationDetector(config, projectPath, new ProjectTagProvider(), tw);
 
-            this.projectPathViolationDetectorFactory = (config, projectPath, repositoryRoot) =>
-                pathViolationDetector ?? new ProjectPathViolationDetector(config, projectPath, new ProjectPathProvider(repositoryRoot));
+            this.projectPathViolationDetectorFactory = (config, projectPath, repositoryRoot, tw) =>
+                pathViolationDetector ?? new ProjectPathViolationDetector(config, projectPath, new ProjectPathProvider(repositoryRoot), tw);
+
+            this.traceWriterFactory = traceWriterFactory ?? (enableTracing =>
+            {
+                if (enableTracing)
+                {
+                    return new TraceWriter();
+                }
+
+                return NullTraceWriter.Instance;
+            });
         }
 
         public IBuildEngine BuildEngine { get; set; }
@@ -73,9 +98,16 @@
                 var configLoader = this.configLoaderFactory(configFilePath);
                 var config = configLoader.Load();
 
+                var traceWriter = this.traceWriterFactory(config.EnableTracing);
+
                 if (config.EnableDebugMessages && config.UseExperimentalDetectors)
                 {
                     this.BuildEngine.LogDebugMessage("Using experimental detectors");
+                }
+
+                if (config.EnableTracing)
+                {
+                    this.BuildEngine.LogDebugMessage("Tracing is enabled");
                 }
 
                 var projectReferences = this.projectReferencesProvider.GetProjectReferences(this.ProjectFile.ItemSpec);
@@ -83,7 +115,7 @@
                     .Select(_ => ReferenceEvaluationContextFactory.Create(_.Path, _.NoWarn))
                     .ToList();
 
-                var projectTagViolationDetector = this.projectTagViolationDetectorFactory(config, this.ProjectFile.ItemSpec);
+                var projectTagViolationDetector = this.projectTagViolationDetectorFactory(config, this.ProjectFile.ItemSpec, traceWriter);
                 var projectTagViolations = config.UseExperimentalDetectors
                     ? projectTagViolationDetector.GetViolationsFromExperimental(evaluationContexts)
                     : projectTagViolationDetector.GetViolationsFrom(evaluationContexts);
@@ -100,7 +132,7 @@
 
                 var repositoryRoot = this.projectReferencesProvider.GetPropertyValue(
                     this.ProjectFile.ItemSpec, ReferenceCopRepositoryRootProperty);
-                var projectPathViolationDetector = this.projectPathViolationDetectorFactory(config, this.ProjectFile.ItemSpec, repositoryRoot);
+                var projectPathViolationDetector = this.projectPathViolationDetectorFactory(config, this.ProjectFile.ItemSpec, repositoryRoot, traceWriter);
                 var projectPathViolations = config.UseExperimentalDetectors
                     ? projectPathViolationDetector.GetViolationsFromExperimental(evaluationContexts)
                     : projectPathViolationDetector.GetViolationsFrom(evaluationContexts);
@@ -113,6 +145,15 @@
                     }
 
                     this.BuildEngine.LogViolation(violation, this.ProjectFile.ItemSpec);
+                }
+
+                // Flush trace messages to the build log
+                if (traceWriter is TraceWriter tw)
+                {
+                    foreach (var message in tw.Messages)
+                    {
+                        this.BuildEngine.LogTraceMessage(message);
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/ReferenceCop.Roslyn/ReferenceCopAnalyzer.cs
+++ b/src/ReferenceCop.Roslyn/ReferenceCopAnalyzer.cs
@@ -42,7 +42,11 @@
                 {
                     var configLoader = new XmlConfigurationLoader(compilationAnalysisContext);
                     this.config = configLoader.Load();
-                    this.assemblyNameViolationDetector = new AssemblyNameViolationDetector(new PatternMatchComparer(), this.config);
+                    var traceWriter = this.config.EnableTracing
+                        ? (ITraceWriter)new TraceWriter()
+                        : NullTraceWriter.Instance;
+
+                    this.assemblyNameViolationDetector = new AssemblyNameViolationDetector(new PatternMatchComparer(), this.config, traceWriter);
 
                     if (this.config.EnableDebugMessages && this.config.UseExperimentalDetectors)
                     {
@@ -51,6 +55,16 @@
                     }
 
                     this.AnalyzeCompilation(compilationAnalysisContext);
+
+                    // Flush trace messages as diagnostics
+                    if (traceWriter is TraceWriter tw)
+                    {
+                        foreach (var message in tw.Messages)
+                        {
+                            compilationAnalysisContext.ReportDiagnostic(
+                                DiagnosticFactory.CreateDebugMessage($"[TRACE]: {message}"));
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/ReferenceCop/Configuration/ReferenceCopConfig.cs
+++ b/src/ReferenceCop/Configuration/ReferenceCopConfig.cs
@@ -13,6 +13,7 @@
             this.Rules = new List<Rule>();
             this.UseExperimentalDetectors = false;
             this.EnableDebugMessages = false;
+            this.EnableTracing = false;
         }
 
         [XmlElement]
@@ -20,6 +21,9 @@
 
         [XmlElement]
         public bool EnableDebugMessages { get; set; }
+
+        [XmlElement]
+        public bool EnableTracing { get; set; }
 
         [XmlArrayItem(typeof(AssemblyName))]
         [XmlArrayItem(typeof(ProjectTag))]

--- a/src/ReferenceCop/Detectors/AssemblyNameViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/AssemblyNameViolationDetector.cs
@@ -11,11 +11,18 @@
         private readonly Dictionary<string, ReferenceCopConfig.Rule> exactMatchRules;
         private readonly List<KeyValuePair<string, ReferenceCopConfig.Rule>> patternRules;
         private readonly IEqualityComparer<string> referenceNameComparer;
+        private readonly ITraceWriter traceWriter;
 
         public AssemblyNameViolationDetector(IEqualityComparer<string> referenceNameComparer, ReferenceCopConfig config)
+            : this(referenceNameComparer, config, NullTraceWriter.Instance)
+        {
+        }
+
+        public AssemblyNameViolationDetector(IEqualityComparer<string> referenceNameComparer, ReferenceCopConfig config, ITraceWriter traceWriter)
         {
             this.rules = new Dictionary<string, ReferenceCopConfig.Rule>(referenceNameComparer);
             this.referenceNameComparer = referenceNameComparer;
+            this.traceWriter = traceWriter ?? NullTraceWriter.Instance;
 
             // Separate exact matches from patterns for performance optimization.
             this.exactMatchRules = new Dictionary<string, ReferenceCopConfig.Rule>(StringComparer.InvariantCulture);
@@ -26,6 +33,11 @@
 
         public IEnumerable<Violation> GetViolationsFrom(IEnumerable<ReferenceEvaluationContext<AssemblyIdentity>> references)
         {
+            if (this.traceWriter.IsEnabled)
+            {
+                this.traceWriter.Write($"[AssemblyNameViolationDetector] Evaluating references against {this.rules.Count} rule(s)");
+            }
+
             foreach (var rule in this.rules)
             {
                 foreach (var referenceContext in references)
@@ -41,7 +53,17 @@
                         // Check if this warning should be suppressed
                         if (referenceContext.IsWarningSuppressed)
                         {
+                            if (this.traceWriter.IsEnabled)
+                            {
+                                this.traceWriter.Write($"[AssemblyNameViolationDetector] Rule '{rule.Value.Name}': violation suppressed for '{reference.Name}'");
+                            }
+
                             continue;
+                        }
+
+                        if (this.traceWriter.IsEnabled)
+                        {
+                            this.traceWriter.Write($"[AssemblyNameViolationDetector] Rule '{rule.Value.Name}': VIOLATION for '{reference.Name}' (pattern='{rule.Key}')");
                         }
 
                         yield return new Violation(rule.Value, reference.Name);
@@ -72,12 +94,22 @@
                 // Skip if warning is suppressed
                 if (referenceContext.IsWarningSuppressed)
                 {
+                    if (this.traceWriter.IsEnabled)
+                    {
+                        this.traceWriter.Write($"[AssemblyNameViolationDetector] Reference '{reference.Name}': warning suppressed, skipping");
+                    }
+
                     continue;
                 }
 
                 // Check exact match rules with O(1) lookup
                 if (this.exactMatchRules.TryGetValue(reference.Name, out var exactRule))
                 {
+                    if (this.traceWriter.IsEnabled)
+                    {
+                        this.traceWriter.Write($"[AssemblyNameViolationDetector] Rule '{exactRule.Name}': VIOLATION for '{reference.Name}' (exact match)");
+                    }
+
                     yield return new Violation(exactRule, reference.Name);
                 }
 
@@ -86,6 +118,11 @@
                 {
                     if (this.referenceNameComparer.Equals(patternRule.Key, reference.Name))
                     {
+                        if (this.traceWriter.IsEnabled)
+                        {
+                            this.traceWriter.Write($"[AssemblyNameViolationDetector] Rule '{patternRule.Value.Name}': VIOLATION for '{reference.Name}' (pattern='{patternRule.Key}')");
+                        }
+
                         yield return new Violation(patternRule.Value, reference.Name);
                     }
                 }

--- a/src/ReferenceCop/Detectors/ProjectPathViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/ProjectPathViolationDetector.cs
@@ -9,22 +9,40 @@
 
         private readonly string projectFilePath;
         private readonly IProjectPathProvider projectPathProvider;
+        private readonly ITraceWriter traceWriter;
 
         public ProjectPathViolationDetector(ReferenceCopConfig config, string projectFilePath, IProjectPathProvider projectPathProvider)
+            : this(config, projectFilePath, projectPathProvider, NullTraceWriter.Instance)
+        {
+        }
+
+        public ProjectPathViolationDetector(ReferenceCopConfig config, string projectFilePath, IProjectPathProvider projectPathProvider, ITraceWriter traceWriter)
         {
             this.LoadRulesFrom(config);
             this.projectFilePath = projectFilePath;
             this.projectPathProvider = projectPathProvider;
+            this.traceWriter = traceWriter ?? NullTraceWriter.Instance;
         }
 
         public IEnumerable<Violation> GetViolationsFrom(IEnumerable<ReferenceEvaluationContext<string>> references)
         {
             var fromProjectPath = this.projectPathProvider.GetRelativePath(this.projectFilePath);
 
+            if (this.traceWriter.IsEnabled)
+            {
+                this.traceWriter.Write($"[ProjectPathViolationDetector] Evaluating project '{this.projectFilePath}' with relative path '{fromProjectPath}'");
+                this.traceWriter.Write($"[ProjectPathViolationDetector] Loaded {this.rules.Count} rule(s)");
+            }
+
             foreach (var rule in this.rules)
             {
                 if (fromProjectPath.StartsWith(rule.FromPath))
                 {
+                    if (this.traceWriter.IsEnabled)
+                    {
+                        this.traceWriter.Write($"[ProjectPathViolationDetector] Rule '{rule.Name}': FromPath '{rule.FromPath}' matches project path '{fromProjectPath}'");
+                    }
+
                     foreach (var referenceContext in references)
                     {
                         var toProjectPath = this.projectPathProvider.GetRelativePath(referenceContext.Reference);
@@ -34,12 +52,30 @@
                             // Check if this warning should be suppressed
                             if (referenceContext.IsWarningSuppressed)
                             {
+                                if (this.traceWriter.IsEnabled)
+                                {
+                                    this.traceWriter.Write($"[ProjectPathViolationDetector] Rule '{rule.Name}': violation suppressed for reference '{referenceContext.Reference}'");
+                                }
+
                                 continue;
+                            }
+
+                            if (this.traceWriter.IsEnabled)
+                            {
+                                this.traceWriter.Write($"[ProjectPathViolationDetector] Rule '{rule.Name}': VIOLATION for reference '{referenceContext.Reference}' (ToPath='{toProjectPath}')");
                             }
 
                             yield return new Violation(rule, referenceContext.Reference);
                         }
+                        else if (this.traceWriter.IsEnabled)
+                        {
+                            this.traceWriter.Write($"[ProjectPathViolationDetector] Rule '{rule.Name}': reference path '{toProjectPath}' does not start with '{rule.ToPath}', no match");
+                        }
                     }
+                }
+                else if (this.traceWriter.IsEnabled)
+                {
+                    this.traceWriter.Write($"[ProjectPathViolationDetector] Rule '{rule.Name}': FromPath '{rule.FromPath}' does not match project path '{fromProjectPath}', skipping");
                 }
             }
         }

--- a/src/ReferenceCop/Detectors/ProjectTagViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/ProjectTagViolationDetector.cs
@@ -9,22 +9,40 @@
 
         private readonly string projectFilePath;
         private readonly IProjectTagProvider projectTagProvider;
+        private readonly ITraceWriter traceWriter;
 
         public ProjectTagViolationDetector(ReferenceCopConfig config, string projectFilePath, IProjectTagProvider projectTagProvider)
+            : this(config, projectFilePath, projectTagProvider, NullTraceWriter.Instance)
+        {
+        }
+
+        public ProjectTagViolationDetector(ReferenceCopConfig config, string projectFilePath, IProjectTagProvider projectTagProvider, ITraceWriter traceWriter)
         {
             this.LoadRulesFrom(config);
             this.projectFilePath = projectFilePath;
             this.projectTagProvider = projectTagProvider;
+            this.traceWriter = traceWriter ?? NullTraceWriter.Instance;
         }
 
         public IEnumerable<Violation> GetViolationsFrom(IEnumerable<ReferenceEvaluationContext<string>> references)
         {
             var fromProjectTag = this.projectTagProvider.GetProjectTag(this.projectFilePath);
 
+            if (this.traceWriter.IsEnabled)
+            {
+                this.traceWriter.Write($"[ProjectTagViolationDetector] Evaluating project '{this.projectFilePath}' with tag '{fromProjectTag}'");
+                this.traceWriter.Write($"[ProjectTagViolationDetector] Loaded {this.rules.Count} rule(s)");
+            }
+
             foreach (var rule in this.rules)
             {
                 if (fromProjectTag == rule.FromProjectTag)
                 {
+                    if (this.traceWriter.IsEnabled)
+                    {
+                        this.traceWriter.Write($"[ProjectTagViolationDetector] Rule '{rule.Name}' matched FromProjectTag '{rule.FromProjectTag}'");
+                    }
+
                     foreach (var referenceContext in references)
                     {
                         var toProjectTag = this.projectTagProvider.GetProjectTag(referenceContext.Reference);
@@ -34,12 +52,30 @@
                             // Check if this warning should be suppressed
                             if (referenceContext.IsWarningSuppressed)
                             {
+                                if (this.traceWriter.IsEnabled)
+                                {
+                                    this.traceWriter.Write($"[ProjectTagViolationDetector] Rule '{rule.Name}': violation suppressed for reference '{referenceContext.Reference}'");
+                                }
+
                                 continue;
+                            }
+
+                            if (this.traceWriter.IsEnabled)
+                            {
+                                this.traceWriter.Write($"[ProjectTagViolationDetector] Rule '{rule.Name}': VIOLATION for reference '{referenceContext.Reference}' (ToProjectTag='{toProjectTag}')");
                             }
 
                             yield return new Violation(rule, referenceContext.Reference);
                         }
+                        else if (this.traceWriter.IsEnabled)
+                        {
+                            this.traceWriter.Write($"[ProjectTagViolationDetector] Rule '{rule.Name}': reference '{referenceContext.Reference}' has tag '{toProjectTag}', no match with '{rule.ToProjectTag}'");
+                        }
                     }
+                }
+                else if (this.traceWriter.IsEnabled)
+                {
+                    this.traceWriter.Write($"[ProjectTagViolationDetector] Rule '{rule.Name}': FromProjectTag '{rule.FromProjectTag}' does not match project tag '{fromProjectTag}', skipping");
                 }
             }
         }

--- a/src/ReferenceCop/Tracing/ITraceWriter.cs
+++ b/src/ReferenceCop/Tracing/ITraceWriter.cs
@@ -1,0 +1,19 @@
+namespace ReferenceCop
+{
+    /// <summary>
+    /// Interface for writing trace messages during rule evaluation.
+    /// </summary>
+    public interface ITraceWriter
+    {
+        /// <summary>
+        /// Writes a trace message.
+        /// </summary>
+        /// <param name="message">The trace message.</param>
+        void Write(string message);
+
+        /// <summary>
+        /// Gets a value indicating whether tracing is enabled.
+        /// </summary>
+        bool IsEnabled { get; }
+    }
+}

--- a/src/ReferenceCop/Tracing/NullTraceWriter.cs
+++ b/src/ReferenceCop/Tracing/NullTraceWriter.cs
@@ -1,0 +1,17 @@
+namespace ReferenceCop
+{
+    /// <summary>
+    /// A no-op trace writer that discards all messages. Used when tracing is disabled.
+    /// </summary>
+    public class NullTraceWriter : ITraceWriter
+    {
+        public static readonly NullTraceWriter Instance = new NullTraceWriter();
+
+        public bool IsEnabled => false;
+
+        public void Write(string message)
+        {
+            // Intentionally empty.
+        }
+    }
+}

--- a/src/ReferenceCop/Tracing/TraceWriter.cs
+++ b/src/ReferenceCop/Tracing/TraceWriter.cs
@@ -1,0 +1,40 @@
+namespace ReferenceCop
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A trace writer that collects trace messages in memory.
+    /// Messages can be retrieved via the <see cref="Messages"/> property or
+    /// forwarded to an external handler via the <see cref="OnMessage"/> callback.
+    /// </summary>
+    public class TraceWriter : ITraceWriter
+    {
+        private readonly List<string> messages = new List<string>();
+
+        /// <summary>
+        /// Gets a value indicating whether tracing is enabled.
+        /// </summary>
+        public bool IsEnabled => true;
+
+        /// <summary>
+        /// Gets the collected trace messages.
+        /// </summary>
+        public IReadOnlyList<string> Messages => this.messages;
+
+        /// <summary>
+        /// Gets or sets an optional callback invoked for each trace message.
+        /// </summary>
+        public Action<string> OnMessage { get; set; }
+
+        /// <summary>
+        /// Writes a trace message.
+        /// </summary>
+        /// <param name="message">The trace message.</param>
+        public void Write(string message)
+        {
+            this.messages.Add(message);
+            this.OnMessage?.Invoke(message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces tracing capabilities to help debug why certain references trigger specific rules.

## Changes

### New files
- `src/ReferenceCop/Tracing/ITraceWriter.cs` — Interface for trace output
- `src/ReferenceCop/Tracing/NullTraceWriter.cs` — No-op implementation (zero overhead when disabled)
- `src/ReferenceCop/Tracing/TraceWriter.cs` — Collects trace messages in memory

### Modified files
- `ReferenceCopConfig.cs` — Added `EnableTracing` config property
- `ReferenceCopConfig.xsd` — Added `EnableTracing` schema element
- `ProjectTagViolationDetector.cs` — Traces rule evaluation (match/skip/suppress/violation)
- `ProjectPathViolationDetector.cs` — Traces rule evaluation (match/skip/suppress/violation)
- `AssemblyNameViolationDetector.cs` — Traces rule evaluation (match/suppress/violation)
- `BuildEngineExtensions.cs` — Added `LogTraceMessage` for MSBuild output
- `ReferenceCopTask.cs` — Creates trace writer from config, flushes traces to build log
- `ReferenceCopAnalyzer.cs` — Creates trace writer, flushes traces as debug diagnostics

## How to use

Set `<EnableTracing>true</EnableTracing>` in your ReferenceCop config file. Trace messages will appear:
- **MSBuild task**: as normal-importance build messages with `[TRACE]` prefix (visible with `-v:normal` or higher)
- **Roslyn analyzer**: as debug diagnostics (RC9999)

## Design decisions
- Zero overhead when tracing is disabled (`NullTraceWriter.IsEnabled` short-circuits all string interpolation)
- Backward compatible — all existing constructors preserved via overload chaining
- No new dependencies

Fixes #31