### PR TITLE
fix: add .env exclusion to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ archive/
 
 # Claude Code local settings
 .claude/settings.local.json
+# Environment files
+.env
+.env.*
+*.env


### PR DESCRIPTION
## Summary

Adds .env file patterns to .gitignore to prevent accidental commit of environment files containing secrets.

## Changes

- Added `.env`, `.env.*`, and `*.env` patterns to `.gitignore`

Fixes mfogliatto/ReferenceCop#64