### PR TITLE
fix: share ProjectCollection instance and implement IDisposable

### DIFF
--- a/src/ReferenceCop.MSBuild/Providers/MSBuildProjectMetadataProvider.cs
+++ b/src/ReferenceCop.MSBuild/Providers/MSBuildProjectMetadataProvider.cs
@@ -1,5 +1,6 @@
 namespace ReferenceCop.MSBuild
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Build.Evaluation;
@@ -7,10 +8,21 @@ namespace ReferenceCop.MSBuild
     /// <summary>
     /// Provides project reference information using MSBuild project evaluation.
     /// </summary>
-    public class MSBuildProjectMetadataProvider : IProjectMetadataProvider
+    public class MSBuildProjectMetadataProvider : IProjectMetadataProvider, IDisposable
     {
         private const string ProjectReferenceNode = "ProjectReference";
         private const string NoWarnMetadata = "NoWarn";
+
+        private readonly ProjectCollection projectCollection;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MSBuildProjectMetadataProvider"/> class.
+        /// </summary>
+        public MSBuildProjectMetadataProvider()
+        {
+            this.projectCollection = new ProjectCollection();
+        }
 
         /// <summary>
         /// Gets the project references from a project file.
@@ -19,8 +31,7 @@ namespace ReferenceCop.MSBuild
         /// <returns>The collection of project references.</returns>
         public IEnumerable<ProjectReferenceInfo> GetProjectReferences(string projectFilePath)
         {
-            var projectCollection = new ProjectCollection();
-            var project = projectCollection.LoadProject(projectFilePath);
+            var project = this.LoadOrGetProject(projectFilePath);
 
             // Get all ProjectReference items. These are the direct project references.
             var projectReferences = project.GetItems(ProjectReferenceNode);
@@ -47,11 +58,48 @@ namespace ReferenceCop.MSBuild
         /// <returns>The resolved property value.</returns>
         public string GetPropertyValue(string projectFilePath, string propertyName)
         {
-            var projectCollection = new ProjectCollection();
-            var project = projectCollection.LoadProject(projectFilePath);
+            var project = this.LoadOrGetProject(projectFilePath);
             project.ReevaluateIfNecessary();
 
             return project.GetPropertyValue(propertyName);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the resources used by the <see cref="MSBuildProjectMetadataProvider"/>.
+        /// </summary>
+        /// <param name="disposing">Whether managed resources should be disposed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    this.projectCollection.UnloadAllProjects();
+                    this.projectCollection.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        private Project LoadOrGetProject(string projectFilePath)
+        {
+            var fullPath = System.IO.Path.GetFullPath(projectFilePath);
+            var loaded = this.projectCollection.GetLoadedProjects(fullPath);
+
+            if (loaded.Count > 0)
+            {
+                return loaded.First();
+            }
+
+            return this.projectCollection.LoadProject(fullPath);
         }
     }
 }

--- a/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
+++ b/src/ReferenceCop.MSBuild/ReferenceCopTask.cs
@@ -120,6 +120,10 @@
                 success = false;
                 this.BuildEngine.LogErrorEvent(ex);
             }
+            finally
+            {
+                (this.projectReferencesProvider as IDisposable)?.Dispose();
+            }
 
             return success;
         }


### PR DESCRIPTION
## Summary

Fixes #68 — eliminates redundant `ProjectCollection` instances and project loads, and properly disposes the `IDisposable` resource.

## Problem

`MSBuildProjectMetadataProvider` was creating a **new `ProjectCollection`** and calling `LoadProject()` in both `GetProjectReferences()` and `GetPropertyValue()`. Since `ReferenceCopTask.Execute()` calls both methods for the same project file, this caused:

1. **Double project evaluation** — full MSBuild project parsing (XML, properties, imports) happening twice per task invocation
2. **Resource leak** — `ProjectCollection` implements `IDisposable` but was never disposed, leaking unmanaged resources (COM interop, file handles)
3. **Build-time cost** — compounds across a solution: 2N unnecessary evaluations for N projects

## Changes

### `MSBuildProjectMetadataProvider.cs`
- Now holds a **single shared `ProjectCollection`** created in the constructor
- Added `LoadOrGetProject()` helper that checks `ProjectCollection.GetLoadedProjects()` before loading, so the project is only parsed **once** even when both methods are called
- Implements `IDisposable` with proper dispose pattern (`UnloadAllProjects()` + `Dispose()` on the collection)

### `ReferenceCopTask.cs`
- `Execute()` now disposes the provider in a `finally` block via safe cast: `(this.projectReferencesProvider as IDisposable)?.Dispose()`
- Safe for test scenarios where mocked providers don't implement `IDisposable`

## Impact

- **50% reduction** in MSBuild project evaluations per task invocation
- **No more resource leaks** from undisposed `ProjectCollection` instances
- Backward compatible — no interface changes, no new dependencies