### PR TITLE
fix: cache FixableDiagnosticIds as static ImmutableArray.Empty

### DIFF
--- a/src/ReferenceCop.Roslyn.CodeFixes/ReferenceCopCodeFixProvider.cs
+++ b/src/ReferenceCop.Roslyn.CodeFixes/ReferenceCopCodeFixProvider.cs
@@ -18,7 +18,7 @@
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds
         {
-            get { return Enumerable.Empty<string>().ToImmutableArray<string>(); }
+            get { return ImmutableArray<string>.Empty; }
         }
 
         public sealed override FixAllProvider GetFixAllProvider()


### PR DESCRIPTION
## Summary

Replaces the per-access allocation in `FixableDiagnosticIds` with the cached `ImmutableArray<string>.Empty` singleton.

### Before
```csharp
get { return Enumerable.Empty<string>().ToImmutableArray<string>(); }
```
Every property access allocated a new `ImmutableArray<string>` via LINQ.

### After
```csharp
get { return ImmutableArray<string>.Empty; }
```
Returns the pre-allocated static empty array — zero allocations.

Fixes #72