### PR TITLE
perf: cache repository root URI to avoid allocations in hot loop

### DIFF
--- a/src/ReferenceCop/Providers/ProjectPathProvider.cs
+++ b/src/ReferenceCop/Providers/ProjectPathProvider.cs
@@ -5,7 +5,7 @@
 
     public class ProjectPathProvider : IProjectPathProvider
     {
-        private readonly string repositoryRoot;
+        private readonly Uri repositoryRootUri;
 
         public ProjectPathProvider(string repositoryRoot)
         {
@@ -14,7 +14,10 @@
                 throw new ArgumentNullException(nameof(repositoryRoot));
             }
 
-            this.repositoryRoot = repositoryRoot;
+            string normalizedRoot = Path.GetFullPath(repositoryRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            this.repositoryRootUri = new Uri(normalizedRoot);
         }
 
         /// <summary>
@@ -28,14 +31,11 @@
                 throw new ArgumentNullException(nameof(projectFilePath));
             }
 
-            string relativeTo = this.repositoryRoot;
-            relativeTo = Path.GetFullPath(relativeTo).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
             projectFilePath = Path.GetFullPath(projectFilePath);
 
-            Uri relativeToUri = new Uri(relativeTo);
             Uri projectFilePathUri = new Uri(projectFilePath);
 
-            Uri relativeUri = relativeToUri.MakeRelativeUri(projectFilePathUri);
+            Uri relativeUri = this.repositoryRootUri.MakeRelativeUri(projectFilePathUri);
             string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
 
             relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);


### PR DESCRIPTION
## Summary

Cache the repository root `Uri` in the `ProjectPathProvider` constructor instead of recomputing it on every `GetRelativePath` call.

## Problem

`GetRelativePath()` is called in the inner loop of `ProjectPathViolationDetector.GetViolationsFrom()` — once per reference × matching rule combination. Each call was:

1. Computing `Path.GetFullPath(repositoryRoot)` (same every time)
2. Trimming and appending separator (same every time)
3. Allocating a `new Uri(...)` for the repository root (same every time)

For 20 rules × 50 references, that is up to 2,000 redundant `Uri` allocations, `Path.GetFullPath` calls, and string operations per project build.

## Fix

Moved the repository root normalization (`Path.GetFullPath` + trim + separator) and `Uri` construction into the constructor, storing it as a `readonly Uri repositoryRootUri` field. `GetRelativePath` now reuses this cached URI.

This eliminates:
- 1 × `Path.GetFullPath` call per invocation
- 1 × string trim + concatenation per invocation
- 1 × `Uri` allocation per invocation

The per-call `Uri` allocation for `projectFilePath` remains since that varies per call.

## Changes

- `src/ReferenceCop/Providers/ProjectPathProvider.cs` — field changed from `string repositoryRoot` to `Uri repositoryRootUri`; normalization moved to constructor

## Testing

All existing tests pass (72/72 non-platform-specific tests pass; 8 Windows-path DataRow tests fail on Linux identically on `main`).

Fixes #67