### PR TITLE
fix: replace Dictionary with List for wildcard-compatible rule storage

### DIFF
--- a/src/ReferenceCop/Detectors/AssemblyNameViolationDetector.cs
+++ b/src/ReferenceCop/Detectors/AssemblyNameViolationDetector.cs
@@ -7,14 +7,14 @@
 
     public class AssemblyNameViolationDetector : IViolationDetector<AssemblyIdentity>
     {
-        private readonly Dictionary<string, ReferenceCopConfig.Rule> rules;
+        private readonly List<KeyValuePair<string, ReferenceCopConfig.Rule>> rules;
         private readonly Dictionary<string, ReferenceCopConfig.Rule> exactMatchRules;
         private readonly List<KeyValuePair<string, ReferenceCopConfig.Rule>> patternRules;
         private readonly IEqualityComparer<string> referenceNameComparer;
 
         public AssemblyNameViolationDetector(IEqualityComparer<string> referenceNameComparer, ReferenceCopConfig config)
         {
-            this.rules = new Dictionary<string, ReferenceCopConfig.Rule>(referenceNameComparer);
+            this.rules = new List<KeyValuePair<string, ReferenceCopConfig.Rule>>();
             this.referenceNameComparer = referenceNameComparer;
 
             // Separate exact matches from patterns for performance optimization.
@@ -103,15 +103,13 @@
             var assemblyNameRules = config.Rules.OfType<ReferenceCopConfig.AssemblyName>();
             foreach (var rule in assemblyNameRules)
             {
-                // Load into original dictionary for backward compatibility
-                try
-                {
-                    this.rules.Add(rule.Pattern, rule);
-                }
-                catch (ArgumentException)
+                // Check for duplicate patterns using the comparer's Equals method
+                if (this.rules.Any(r => this.referenceNameComparer.Equals(r.Key, rule.Pattern)))
                 {
                     throw new InvalidOperationException($"Duplicate rule pattern '{rule.Pattern}' found in the configuration file.");
                 }
+
+                this.rules.Add(new KeyValuePair<string, ReferenceCopConfig.Rule>(rule.Pattern, rule));
 
                 // Also load into optimized structures - separate exact matches from patterns
                 if (IsExactMatch(rule.Pattern))


### PR DESCRIPTION
## Summary

Replaces the `Dictionary<string, Rule>` field `rules` in `AssemblyNameViolationDetector` with `List<KeyValuePair<string, Rule>>` to fix a broken `IEqualityComparer` contract.

## Problem

`PatternMatchComparer.GetHashCode` uses the default `string.GetHashCode()`, which violates the `IEqualityComparer<string>` contract: when `Equals("*", "SomeAssembly")` returns `true`, their hash codes differ. This means:

- Any `Dictionary` using this comparer cannot perform correct hash-based lookups for wildcard keys
- Duplicate pattern detection via `Dictionary.Add` was also broken (two patterns the comparer considers equal but with different hashes would not be detected as duplicates)
- The bug was masked because `GetViolationsFrom` iterates the dictionary via `foreach`, bypassing hash lookups entirely

## Fix

Since `rules` is only iterated (never looked up by key), replace it with a `List<KeyValuePair<>>` — this correctly reflects the actual usage pattern and eliminates the broken hash dependency.

Duplicate detection now uses the comparer's `Equals` method directly via `List.Any()`, which is correct for all comparer types including wildcard-aware ones.

The `exactMatchRules` dictionary (using `StringComparer.InvariantCulture`) and `patternRules` list in the experimental path are unaffected.

## Testing

All 18 `AssemblyNameViolationDetectorTests` pass. The 8 pre-existing failures in `ProjectPathProviderTests` are unrelated (Windows path tests on Linux).

Fixes #70